### PR TITLE
Fixed Rich Text fields getting returned as empty objects

### DIFF
--- a/jsonexpand/services/JsonExpandService.php
+++ b/jsonexpand/services/JsonExpandService.php
@@ -98,7 +98,12 @@ class JsonExpandService extends BaseApplicationComponent {
                   $subValue = array_merge((array)$subValue);
               }
 
-              $relatedArray[$subHandle] = $subValue;
+              if($subField['type'] == "RichText") {
+                // Rich Text field values need to be converted to a string
+                $relatedArray[$subHandle] = (string)$subValue;
+              } else {
+                $relatedArray[$subHandle] = $subValue;
+              }
 
             }
             // add the item to the fields array
@@ -108,12 +113,17 @@ class JsonExpandService extends BaseApplicationComponent {
 
 
 
+        } else if($field['type'] == "RichText") {
+
+          // Rich Text field values need to be converted to a string
+          $entryData[$handle] = (string)$value;
+
         } else {
           // just set the field value to the field
 
 
             $entryData[$handle] = $value;
-          
+
 
 
           //echo $field['type'];


### PR DESCRIPTION
I came across this issue myself, but this StackExchange question describes the problem accurately also (I posted this same solution to that question as well): https://craftcms.stackexchange.com/questions/13748/rich-text-field-is-returning-an-empty-object-over-api-of-plugin-json-expand/22083#22083